### PR TITLE
fix jedi migration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "ayrel/phpas2",
+  "name": "bestpostmaster/phpas2",
   "description": "PHPAS2 is a php-based implementation of the EDIINT AS2 standard",
   "version": "1.3.4.1",
   "authors": [
@@ -21,7 +21,7 @@
     "ext-zlib": "*",
     "ext-openssl": "*",
     "psr/log": "^1.0",
-    "guzzlehttp/guzzle": "^6.3",
+    "guzzlehttp/guzzle": "^7.4",
     "phpseclib/phpseclib": "^2.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "ext-zlib": "*",
     "ext-openssl": "*",
     "psr/log": "^1.0",
-    "guzzlehttp/guzzle": "^6.3",
+    "guzzlehttp/guzzle": "^7.4",
     "phpseclib/phpseclib": "^2.0"
   },
   "require-dev": {


### PR DESCRIPTION
fix jedi migration :
Problem :
- ayrel/phpas2[1.3.1, ..., 1.3.4.1] require guzzlehttp/guzzle ^6.3 -> found guzzlehttp/guzzle[6.3.0, ..., 6.5.5] but it conflicts with your root composer.json require (^7.4).
- Root composer.json requires ayrel/phpas2 * -> satisfiable by ayrel/phpas2[1.3.1, ..., 1.3.4.1].